### PR TITLE
Allow plugin to be used on standalone UHC server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
             <id>placeholderapi</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -62,6 +66,12 @@
             <artifactId>placeholderapi</artifactId>
             <version>2.9.2</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.4</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/gmail/mezymc/stats/UhcStats.java
+++ b/src/main/java/com/gmail/mezymc/stats/UhcStats.java
@@ -35,8 +35,12 @@ public class UhcStats extends JavaPlugin{
 
     @Override
     public void onDisable() {
-        for (LeaderBoard leaderBoard : StatsManager.getStatsManager().getLeaderBoards()){
-            leaderBoard.unload();
+        if(StatsManager.getStatsManager().getLeaderBoards() != null) {
+            for (LeaderBoard leaderBoard : StatsManager.getStatsManager().getLeaderBoards()) {
+                if(leaderBoard != null) {
+                    leaderBoard.unload();
+                }
+            }
         }
     }
 

--- a/src/main/java/com/gmail/mezymc/stats/database/SQLiteConnector.java
+++ b/src/main/java/com/gmail/mezymc/stats/database/SQLiteConnector.java
@@ -1,0 +1,224 @@
+package com.gmail.mezymc.stats.database;
+
+import com.gmail.mezymc.stats.GameMode;
+import com.gmail.mezymc.stats.StatType;
+import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import static com.gmail.mezymc.stats.UhcStats.getPlugin;
+
+public class SQLiteConnector implements DatabaseConnector {
+
+    private Connection connection;
+
+    public SQLiteConnector() {
+        connection = null;
+    }
+
+    @Override
+    public List<Position> getTop10(StatType statType, GameMode gameMode) {
+        try {
+            Connection connection = getSqlConnection();
+            Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery("SELECT `id`, `" + statType.getColumnName() + "` FROM `" + gameMode.getTableName() + "` ORDER BY `" + statType.getColumnName() + "` DESC LIMIT 10");
+            List<Position> positions = new ArrayList<>();
+
+            int pos = 1;
+            while (resultSet.next()) {
+                Position position = new Position(
+                        pos,
+                        resultSet.getString("id"),
+                        resultSet.getInt(statType.getColumnName())
+                );
+
+                positions.add(position);
+                pos++;
+            }
+
+            resultSet.close();
+            statement.close();
+
+            return positions;
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+            return new ArrayList<>();
+        }
+    }
+
+    @Override
+    public boolean doesTableExists(String tableName) {
+        Connection connection;
+        Statement statement;
+        try {
+            connection = getSqlConnection();
+            statement = connection.createStatement();
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+            throw new RuntimeException("Failed to create statement!");
+        }
+
+        try {
+            statement.executeQuery("SELECT 1 FROM `" + tableName + "` LIMIT 1;").close();
+            statement.close();
+            return true;
+        } catch (SQLException ex) {
+            return false;
+        }
+    }
+
+    @Override
+    public void createTable(String name, DatabaseColumn... databaseColumns) {
+        StringBuilder sb = new StringBuilder("CREATE TABLE `" + name + "` (");
+        boolean first = true;
+
+        for (DatabaseColumn databaseColumn : databaseColumns) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+
+            sb.append(databaseColumn.toString());
+        }
+        sb.append(");");
+
+        try {
+            Connection connection = getSqlConnection();
+            Statement statement = connection.createStatement();
+            statement.execute(sb.toString());
+            statement.close();
+        } catch (SQLException ex) {
+            Bukkit.getLogger().warning("[UhcStats] Failed to create table!");
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public void pushStats(String playerId, GameMode gameMode, Map<StatType, Integer> stats) {
+        try {
+            Connection connection = getSqlConnection();
+            Statement statement = connection.createStatement();
+            for (StatType statType : stats.keySet()) {
+                statement.executeUpdate(
+                        "UPDATE `" + gameMode.getTableName() + "` SET `" + statType.getColumnName() + "`=" + stats.get(statType) + " WHERE `id`='" + playerId + "'"
+                );
+            }
+            statement.close();
+        } catch (SQLException ex) {
+            Bukkit.getLogger().warning("[UhcStats] Failed to push stats for: " + playerId);
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public Map<StatType, Integer> loadStats(String playerId, GameMode gameMode) {
+        Map<StatType, Integer> stats = getEmptyStatMap();
+
+        try {
+            Connection connection = getSqlConnection();
+            Statement statement = connection.createStatement();
+            ResultSet result = statement.executeQuery("SELECT * FROM `" + gameMode.getTableName() + "` WHERE `id`='" + playerId + "'");
+
+            if (result.next()) {
+                // collect stats
+                for (StatType statType : StatType.values()) {
+                    stats.put(statType, result.getInt(statType.getColumnName()));
+                }
+            } else {
+                // Player not found, insert player to table.
+                insertPlayerToTable(connection, playerId, gameMode);
+            }
+
+            result.close();
+            statement.close();
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        }
+
+        return stats;
+    }
+
+    @Override
+    public boolean checkConnection() {
+        try {
+            getSqlConnection();
+            return true;
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+            return false;
+        }
+    }
+
+    private Connection getSqlConnection() throws SQLException {
+        Validate.isTrue(!Bukkit.isPrimaryThread(), "You may only open an connection to the database on a asynchronous thread!");
+
+        // Open connection to local SQLite database "stats.db"
+        File dataFile = new File(getPlugin().getDataFolder(), "stats.db");
+        if (!dataFile.exists()) {
+            try {
+                dataFile.createNewFile();
+            } catch (IOException e) {
+                Bukkit.getLogger().log(Level.SEVERE, "File write error: stats.db");
+            }
+        }
+        try {
+            if (connection != null && !connection.isClosed()) {
+                return connection;
+            }
+            Class.forName("org.sqlite.JDBC");
+            connection = DriverManager.getConnection("jdbc:sqlite:" + dataFile);
+            return connection;
+        } catch (SQLException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "SQLite exception on initialize", ex);
+        } catch (ClassNotFoundException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "You need the SQLite JBDC library.");
+        }
+
+        return null;
+    }
+
+    private void insertPlayerToTable(Connection connection, String playerId, GameMode gameMode) {
+        try {
+            StringBuilder sb = new StringBuilder("INSERT INTO `" + gameMode.getTableName() + "` (`id`");
+            for (StatType statType : StatType.values()) {
+                sb.append(", `" + statType.getColumnName() + "`");
+            }
+
+            sb.append(") VALUES ('" + playerId + "'");
+
+            for (int i = 0; i < StatType.values().length; i++) {
+                sb.append(", 0");
+            }
+
+            sb.append(")");
+
+            Statement statement = connection.createStatement();
+            statement.execute(sb.toString());
+
+            statement.close();
+        } catch (SQLException ex) {
+            Bukkit.getLogger().warning("[UhcStats] Failed to update stats for: " + playerId);
+            ex.printStackTrace();
+        }
+    }
+
+    private Map<StatType, Integer> getEmptyStatMap() {
+        Map<StatType, Integer> stats = new HashMap<>();
+
+        for (StatType statType : StatType.values()) {
+            stats.put(statType, 0);
+        }
+
+        return stats;
+    }
+
+}

--- a/src/main/java/com/gmail/mezymc/stats/database/SQLiteConnector.java
+++ b/src/main/java/com/gmail/mezymc/stats/database/SQLiteConnector.java
@@ -161,13 +161,13 @@ public class SQLiteConnector implements DatabaseConnector {
     private Connection getSqlConnection() throws SQLException {
         Validate.isTrue(!Bukkit.isPrimaryThread(), "You may only open an connection to the database on a asynchronous thread!");
 
-        // Open connection to local SQLite database "stats.db"
-        File dataFile = new File(getPlugin().getDataFolder(), "stats.db");
+        // Open connection to local SQLite database "database.db"
+        File dataFile = new File(getPlugin().getDataFolder(), "database.db");
         if (!dataFile.exists()) {
             try {
                 dataFile.createNewFile();
             } catch (IOException e) {
-                Bukkit.getLogger().log(Level.SEVERE, "File write error: stats.db");
+                Bukkit.getLogger().log(Level.SEVERE, "File write error: database.db");
             }
         }
         try {

--- a/src/main/java/com/gmail/mezymc/stats/listeners/UhcStatListener.java
+++ b/src/main/java/com/gmail/mezymc/stats/listeners/UhcStatListener.java
@@ -50,10 +50,14 @@ public class UhcStatListener implements Listener{
 
     @EventHandler
     public void onGameStateChangedEvent(UhcGameStateChangedEvent e){
-        // When the game is waiting for players (world have finished being generated), load the leaderboards
-        // This is so that the leaderboards can go in the correct world
-        if(e.getNewGameState() == GameState.WAITING) {
-            Bukkit.getScheduler().runTaskLater(UhcStats.getPlugin(), () -> StatsManager.getStatsManager().loadLeaderBoards(), 10);
+        // If this is a UHC server (and not a lobby server with this plugin installed on it),
+        // load the leader-boards only after the the UHC game world(s) are pre-generated
+        if(StatsManager.getStatsManager().getIsUhcServer()) {
+            // When the game is waiting for players (world(s) have finished being pre-generated), load the leaderboards
+            // This is so that the leaderboards can go in the correct world if the default lobby is used
+            if (e.getNewGameState() == GameState.WAITING) {
+                Bukkit.getScheduler().runTaskLater(UhcStats.getPlugin(), () -> StatsManager.getStatsManager().loadLeaderBoards(), 10);
+            }
         }
     }
 

--- a/src/main/java/com/gmail/mezymc/stats/listeners/UhcStatListener.java
+++ b/src/main/java/com/gmail/mezymc/stats/listeners/UhcStatListener.java
@@ -1,7 +1,9 @@
 package com.gmail.mezymc.stats.listeners;
 
 import com.gmail.mezymc.stats.*;
+import com.gmail.val59000mc.events.UhcGameStateChangedEvent;
 import com.gmail.val59000mc.events.UhcWinEvent;
+import com.gmail.val59000mc.game.GameState;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -44,6 +46,15 @@ public class UhcStatListener implements Listener{
 
         // Push all stats
         Bukkit.getScheduler().runTaskAsynchronously(UhcStats.getPlugin(), () -> statsManager.pushAllStats());
+    }
+
+    @EventHandler
+    public void onGameStateChangedEvent(UhcGameStateChangedEvent e){
+        // When the game is waiting for players (world have finished being generated), load the leaderboards
+        // This is so that the leaderboards can go in the correct world
+        if(e.getNewGameState() == GameState.WAITING) {
+            Bukkit.getScheduler().runTaskLater(UhcStats.getPlugin(), () -> StatsManager.getStatsManager().loadLeaderBoards(), 10);
+        }
     }
 
 }

--- a/src/main/java/com/gmail/mezymc/stats/scoreboards/BoardPosition.java
+++ b/src/main/java/com/gmail/mezymc/stats/scoreboards/BoardPosition.java
@@ -72,7 +72,10 @@ public class BoardPosition {
     }
 
     public void remove(){
-        armorStand.remove();
+        // Only remove armor stand if it was created in the first place
+        if(armorStand != null) {
+            armorStand.remove();
+        }
     }
 
     public Location getLocation(){
@@ -98,11 +101,17 @@ public class BoardPosition {
     private void spawnArmorStand(){
         Location location = getLocation();
 
-        for (Entity entity : location.getWorld().getNearbyEntities(location,1,1,1)){
-            if (entity.getType() == EntityType.ARMOR_STAND && entity.getLocation().equals(location)){
-                armorStand = (ArmorStand) entity;
+        // getNearbyEntities() must be used synchronously
+        LeaderboardUpdateThread.runSync(new Runnable() {
+            @Override
+            public void run() {
+                for (Entity entity : location.getWorld().getNearbyEntities(location, 1, 1, 1)){
+                    if (entity.getType() == EntityType.ARMOR_STAND && entity.getLocation().equals(location)){
+                        armorStand = (ArmorStand) entity;
+                    }
+                }
             }
-        }
+        });
 
         if (armorStand == null){
             LeaderboardUpdateThread.runSync(new Runnable() {

--- a/src/main/java/com/gmail/mezymc/stats/scoreboards/LeaderBoard.java
+++ b/src/main/java/com/gmail/mezymc/stats/scoreboards/LeaderBoard.java
@@ -3,9 +3,7 @@ package com.gmail.mezymc.stats.scoreboards;
 import com.gmail.mezymc.stats.GameMode;
 import com.gmail.mezymc.stats.StatType;
 import com.gmail.mezymc.stats.StatsManager;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
+import org.bukkit.*;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
@@ -41,8 +39,27 @@ public class LeaderBoard{
 
     public void instantiate(ConfigurationSection cfg){
 
+        // Search for correct world to place the leaderboard into
+        World mainUHCWorld = Bukkit.getWorld("world");
+        boolean didFindWorld = false;
+        for(World world : Bukkit.getWorlds()) {
+            // The world must be in the overworld but not the default "world"
+            if(!world.getName().equals("world") && world.getEnvironment() == World.Environment.NORMAL) {
+                // The correct one is the one with the glass box (the default lobby)
+                if(world.getBlockAt(0, 199, 0).getType() == Material.GLASS) {
+                    mainUHCWorld = world;
+                    didFindWorld = true;
+                }
+            }
+        }
+        // If the correct world could not be found, issue a warning
+        if(!didFindWorld) {
+            Bukkit.getLogger().warning("[UhcStats] Could not find world for leaderboard");
+        }
+
+        // Use the correct world in the location specification
         location = new Location(
-                Bukkit.getWorld(cfg.getString("location.world")),
+                mainUHCWorld,
                 cfg.getDouble("location.x"),
                 cfg.getDouble("location.y"),
                 cfg.getDouble("location.z")

--- a/src/main/java/com/gmail/mezymc/stats/scoreboards/LeaderboardUpdateThread.java
+++ b/src/main/java/com/gmail/mezymc/stats/scoreboards/LeaderboardUpdateThread.java
@@ -22,8 +22,11 @@ public class LeaderboardUpdateThread implements Runnable{
             }
         }
 
-        // re-run
-        Bukkit.getScheduler().runTaskLaterAsynchronously(UhcStats.getPlugin(), this, 20*60);
+        // Re-run if need be
+        int leaderboardsUpdateInterval = statsManager.getLeaderBoardsUpdateInterval();
+        if(leaderboardsUpdateInterval > 0) {
+            Bukkit.getScheduler().runTaskLaterAsynchronously(UhcStats.getPlugin(), this, 20 * leaderboardsUpdateInterval);
+        }
     }
 
     public static void runSync(Runnable runnable){

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,25 @@
+# Recommended config options
+
+# For a hub / lobby server in a bungeecord server network:
+# use-mysql-database: true
+# `gamemodes` section must be populated with corresponding gamemode(s) from your actual UHC game server(s)
+
+# For a UHC server in a bungeecord server network:
+# use-mysql-database: true
+# Set `server-gamemode` to type of game being hosted on this UHC server
+
+# For a standalone UHC server:
+# use-mysql-database: false
+# Either remove `gamemodes` section or set `server-gamemode` to `uhc`
+# Set each leaderboard's `gamemode` to `uhc`
+# Remove each leaderboard's `world` section if not using a custom lobby
+
+
+# Database type to use.
+# true: use external MySQL database (primarily for server networks)
+# false:  use local SQLite database file "plugins/UhcStats/database.db" (primarily for standalone servers)
+use-mysql-database: true
+
 # MySql details, in this database the stats will be stored.
 sql:
   ip: 'localhost'
@@ -15,7 +37,8 @@ stats-command: '/stats'
 
 gui-title: '&6&lUHC Stats'
 
-# If you have multiple UHC GameModes on your server you can configure them here. If you only have one you can delete this section.
+# If you are using a server network (e.g. bungeecord) with multiple UHC servers, you can configure them here.
+# If you only have one standalone UHC server you should delete this section.
 gamemodes:
   # The current server GameMode. If this is a UHC server under what GameMode should the statistics be saved?
   server-gamemode: 'cutclean'
@@ -30,19 +53,31 @@ gamemodes:
     name: '&aUhc Run'
     display-item: 'DIAMOND_PICKAXE'
 
+# How often to update the leader-boards, in seconds
+# Set to 0 to disable
+leaderboards-update-interval: 60
+
+# Set this according to the example configuration section below
+# (You can delete this line and adapt the example section to your needs)
 leaderboards: {}
 
 leaderboards-sample:
   board-1:
     # Choose from: KILL, DEATH and WIN
     stat-type: KILL
+    # If gamemodes section above is not used, set the gamemode below to "uhc".
     gamemode: cutclean
+    # Title for this leader-board (can use formatting codes).
     title: '&aCutClean top 10 kills'
-    # Layout of the leader-board lines.
+    # Layout of the leader-board lines (can use formatting codes).
     lines: '&a%number%. %player%: %count%'
     # Location where the leader-board should spawn.
     location:
+      # Remove the "world: world" line to place this leader-board in the default lobby
+      # Otherwise, set the world this leader-board should be created in
+      # If used on a standalone server with the default lobby, this line should be removed
       world: world
+      # Coordinates in world to create the leader-board at ([0x 202y 0z] is the center of the default glass box lobby)
       x: 0
-      y: 50
+      y: 202
       z: 0


### PR DESCRIPTION
### This PR adds features which make it possible to use leader-boards and saving stats on a standalone UHC server without having a MySQL database or separate lobby server in a bungeecord network.

#### Namely:
- Added config option to use local SQLite database instead of MySQL (`use-mysql-database`)
- Added support to automatically place leader-boards in main UHC server lobby, or in a preset world, depending if plugin is used on a UHC server or lobby server

Smaller user-facing changes:
- Added config option for leader-boards update interval (`leaderboards-update-interval`)
- Added more info in comments of config.yml file

Other changes:
- Added null checks to prevent NPE's when disabling plugin if some leaderboards could not be created
- Added paperlib to pom.xml

Please note that the leader-boards are placed in the default lobby world by determining which world has the glass box lobby at y=200. I realize this is not an ideal way to do so, and it would be better to expose this world through the UhcCore API.
I have added comments in the modified code sections to explain what each change is doing.